### PR TITLE
FIX for minor error in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If you're only interested in authentication, the
 
 ## API client
 
-Please view the [API documentation]((http://www.tumblr.com/docs/en/api/v2) for
+Please view the [API documentation](http://www.tumblr.com/docs/en/api/v2) for
 full usage instructions.
 
 There are two ways of retrieving data from the API:


### PR DESCRIPTION
Documentation for the API was not reachable because the markdown was incorrectly specified.
