### PR TITLE
Switched to Foundations Base 64 encoding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,6 @@ which shows all of the inter-app hooks in action.
 ## Dependencies
 
 * [JXHTTP](https://github.com/jstn/JXHTTP)
-* [NSData+Base64](https://github.com/l4u/NSData-Base64)
 
 ## Contact
 

--- a/TMTumblrSDK.podspec
+++ b/TMTumblrSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'TMTumblrSDK'
-  s.version      = '1.0.4'
+  s.version      = '1.0.5'
   s.summary      = 'An unopinionated and flexible library for easily integrating Tumblr data into your iOS or OS X application.'
   s.author       = { 'Bryan Irace' => 'bryan@tumblr.com' }
   s.homepage     = 'http://tumblr.github.com/TMTumblrSDK'
@@ -54,7 +54,6 @@ Pod::Spec.new do |s|
 
     ss.subspec 'Authentication' do |sss|
       sss.source_files = 'TMTumblrSDK/Authentication'
-      sss.dependency   'NSData+Base64', '1.0'
       sss.dependency   'TMTumblrSDK/Core'
     end
   end

--- a/TMTumblrSDK/Authentication/TMOAuth.m
+++ b/TMTumblrSDK/Authentication/TMOAuth.m
@@ -11,7 +11,6 @@
 #import <CommonCrypto/CommonDigest.h>
 #import <CommonCrypto/CommonHMAC.h>
 #import <sys/sysctl.h>
-#import "NSData+Base64.h"
 #import "TMSDKFunctions.h"
 
 @interface TMOAuth()
@@ -90,7 +89,10 @@ NSString *generateBaseString(NSString *baseURL, NSString *method, NSDictionary *
 NSString *sign(NSString *baseString, NSString *consumerSecret, NSString *tokenSecret) {
     NSString *keyString = [NSString stringWithFormat:@"%@&%@", consumerSecret, tokenSecret ? tokenSecret : @""];
     
-    return [HMACSHA1(baseString, keyString) base64EncodedString];
+    NSData *hashedData = HMACSHA1(baseString, keyString);
+    NSString *base64EncodedString = [hashedData base64EncodedStringWithOptions:0];
+    
+    return base64EncodedString;
 }
 
 NSString *UNIXTimestamp(NSDate *date) {


### PR DESCRIPTION
iOS 7, finally, introduced native Base 64 handling, so why not use it?

Tested with the Authentication example app.

Since this is the first time I've worked with Podspecs, I may have missed something. Let me know.
