### PR TITLE
Make `+[TMAPIClient sharedInstance]` instancetype

### DIFF
--- a/TMTumblrSDK/APIClient/TMAPIClient.h
+++ b/TMTumblrSDK/APIClient/TMAPIClient.h
@@ -65,7 +65,7 @@ typedef void (^TMAPICallback)(id, NSError *error);
 
 /** @name Singleton instance */
 
-+ (TMAPIClient *)sharedInstance;
++ (instancetype)sharedInstance;
 
 /** @name Sending raw requests */
 

--- a/TMTumblrSDK/APIClient/TMAPIClient.m
+++ b/TMTumblrSDK/APIClient/TMAPIClient.m
@@ -28,10 +28,10 @@ NSString *URLWithPath(NSString *path);
 
 @implementation TMAPIClient
 
-+ (id)sharedInstance {
++ (instancetype)sharedInstance {
     static TMAPIClient *instance;
     static dispatch_once_t predicate;
-    dispatch_once(&predicate, ^{ instance = [[TMAPIClient alloc] init]; });
+    dispatch_once(&predicate, ^{ instance = [[self alloc] init]; });
     return instance;
 }
 


### PR DESCRIPTION
This makes `TMAPIClient` much more subclass-friendly
