### PR TITLE
Feature post photo as nsdata

### DIFF
--- a/TMTumblrSDK/APIClient/TMAPIClient.h
+++ b/TMTumblrSDK/APIClient/TMAPIClient.h
@@ -244,6 +244,15 @@ typedef void (^TMAPICallback)(id, NSError *error);
 - (void)photo:(NSString *)blogName filePathArray:(NSArray *)filePathArrayOrNil contentTypeArray:(NSArray *)contentTypeArrayOrNil
 fileNameArray:(NSArray *)fileNameArrayOrNil parameters:(NSDictionary *)parameters callback:(TMAPICallback)callback;
 
+
+- (JXHTTPOperation *)photoRequest:(NSString *)blogName imageNSDataArray:(NSArray *)nsdataArrayOrNil
+                 contentTypeArray:(NSArray *)contentTypeArrayOrNil fileNameArray:(NSArray *)fileNameArrayOrNil
+                       parameters:(NSDictionary *)parameters;
+
+- (void)photo:(NSString *)blogName imageNSDataArray:(NSArray *)nsdataArrayOrNil contentTypeArray:(NSArray *)contentTypeArrayOrNil
+fileNameArray:(NSArray *)fileNameArrayOrNil parameters:(NSDictionary *)parameters callback:(TMAPICallback)callback;
+
+
 /// Create a video post
 - (JXHTTPOperation *)videoRequest:(NSString *)blogName filePath:(NSString *)filePathOrNil
                       contentType:(NSString *)contentTypeOrNil fileName:(NSString *)fileNameOrNil

--- a/TMTumblrSDK/APIClient/TMAPIClient.m
+++ b/TMTumblrSDK/APIClient/TMAPIClient.m
@@ -462,7 +462,7 @@ fileNameArray:(NSArray *)fileNameArrayOrNil parameters:(NSDictionary *)parameter
     
     JXHTTPMultipartBody *multipartBody = [JXHTTPMultipartBody withDictionary:mutableParameters];
     
-    BOOL multiple = [nsdataArrayOrNil count] > 1;
+    BOOL multiple = [nsdataArray count] > 1;
     
     [nsdataArray enumerateObjectsUsingBlock:^(NSData *data, NSUInteger index, BOOL *stop) {
         [multipartBody addData:data forKey:multiple ? [NSString stringWithFormat:@"data[%lu]", (unsigned long)index] : @"data"

--- a/TMTumblrSDK/APIClient/TMAPIClient.m
+++ b/TMTumblrSDK/APIClient/TMAPIClient.m
@@ -455,7 +455,7 @@ fileNameArray:(NSArray *)fileNameArrayOrNil parameters:(NSDictionary *)parameter
     return request;
 }
 
-- (JXHTTPMultipartBody *)multipartBodyForParameters:(NSDictionary *)parameters nsDataArray:(NSArray *)nsdataArrayOrNil
+- (JXHTTPMultipartBody *)multipartBodyForParameters:(NSDictionary *)parameters nsDataArray:(NSArray *)nsdataArray
                                    contentTypeArray:(NSArray *)contentTypeArray fileNameArray:(NSArray *)fileNameArray {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
     mutableParameters[@"api_key"] = self.OAuthConsumerKey;
@@ -464,7 +464,7 @@ fileNameArray:(NSArray *)fileNameArrayOrNil parameters:(NSDictionary *)parameter
     
     BOOL multiple = [nsdataArrayOrNil count] > 1;
     
-    [filePathArray enumerateObjectsUsingBlock:^(NSData *data, NSUInteger index, BOOL *stop) {
+    [nsdataArray enumerateObjectsUsingBlock:^(NSData *data, NSUInteger index, BOOL *stop) {
         [multipartBody addData:data forKey:multiple ? [NSString stringWithFormat:@"data[%lu]", (unsigned long)index] : @"data"
                    contentType:contentTypeArray[index] fileName:fileNameArray[index]];
     }];

--- a/TMTumblrSDK/APIClient/TMAPIClient.m
+++ b/TMTumblrSDK/APIClient/TMAPIClient.m
@@ -328,6 +328,22 @@ fileNameArray:(NSArray *)fileNameArrayOrNil parameters:(NSDictionary *)parameter
                            fileNameArray:fileNameArrayOrNil parameters:parameters] callback:(TMAPICallback)callback];
 }
 
+- (JXHTTPOperation *)photoRequest:(NSString *)blogName imageNSDataArray:(NSArray *)nsdataArrayOrNil
+                 contentTypeArray:(NSArray *)contentTypeArrayOrNil fileNameArray:(NSArray *)fileNameArrayOrNil
+                       parameters:(NSDictionary *)parameters
+{
+    return [self multipartPostRequest:blogName type:@"photo" parameters:parameters nsDataArray:nsdataArrayOrNil
+                     contentTypeArray:contentTypeArrayOrNil fileNameArray:fileNameArrayOrNil];
+}
+
+- (void)photo:(NSString *)blogName imageNSDataArray:(NSArray *)nsdataArrayOrNil contentTypeArray:(NSArray *)contentTypeArrayOrNil
+fileNameArray:(NSArray *)fileNameArrayOrNil parameters:(NSDictionary *)parameters callback:(TMAPICallback)callback
+{
+    [self sendRequest:[self photoRequest:blogName imageNSDataArray:nsdataArrayOrNil contentTypeArray:contentTypeArrayOrNil
+                           fileNameArray:fileNameArrayOrNil parameters:parameters] callback:(TMAPICallback)callback];
+
+}
+
 - (JXHTTPOperation *)videoRequest:(NSString *)blogName filePath:(NSString *)filePathOrNil
                       contentType:(NSString *)contentTypeOrNil fileName:(NSString *)fileNameOrNil
                        parameters:(NSDictionary *)parameters {
@@ -418,6 +434,42 @@ fileNameArray:(NSArray *)fileNameArrayOrNil parameters:(NSDictionary *)parameter
     [self signRequest:request withParameters:mutableParameters];
     
     return request;
+}
+
+- (JXHTTPOperation *)multipartPostRequest:(NSString *)blogName type:(NSString *)type parameters:(NSDictionary *)parameters
+                            nsDataArray:(NSArray *)nsdataArrayOrNil contentTypeArray:(NSArray *)contentTypeArray
+                            fileNameArray:(NSArray *)fileNameArray {
+    NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
+    mutableParameters[@"api_key"] = self.OAuthConsumerKey;
+    mutableParameters[@"type"] = type;
+    
+    JXHTTPOperation *request = [JXHTTPOperation withURLString:[self URLWithPath:blogPath(@"post", blogName)]];
+    request.requestMethod = @"POST";
+    request.continuesInAppBackground = YES;
+    request.requestBody = [self multipartBodyForParameters:mutableParameters nsDataArray:nsdataArrayOrNil
+                                          contentTypeArray:contentTypeArray fileNameArray:fileNameArray];
+    request.requestTimeoutInterval = self.timeoutInterval;
+    
+    [self signRequest:request withParameters:mutableParameters];
+    
+    return request;
+}
+
+- (JXHTTPMultipartBody *)multipartBodyForParameters:(NSDictionary *)parameters nsDataArray:(NSArray *)nsdataArrayOrNil
+                                   contentTypeArray:(NSArray *)contentTypeArray fileNameArray:(NSArray *)fileNameArray {
+    NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
+    mutableParameters[@"api_key"] = self.OAuthConsumerKey;
+    
+    JXHTTPMultipartBody *multipartBody = [JXHTTPMultipartBody withDictionary:mutableParameters];
+    
+    BOOL multiple = [nsdataArrayOrNil count] > 1;
+    
+    [filePathArray enumerateObjectsUsingBlock:^(NSData *data, NSUInteger index, BOOL *stop) {
+        [multipartBody addData:data forKey:multiple ? [NSString stringWithFormat:@"data[%lu]", (unsigned long)index] : @"data"
+                   contentType:contentTypeArray[index] fileName:fileNameArray[index]];
+    }];
+    
+    return multipartBody;
 }
 
 - (JXHTTPMultipartBody *)multipartBodyForParameters:(NSDictionary *)parameters filePathArray:(NSArray *)filePathArray


### PR DESCRIPTION
Typically developers have access to UIImage objects and want to share them to Tumblr, it doesn't make sense to store them and then share them.

This change added support for sharing Images from NSData objects instead of files.

Sample Request

``` objective-c

UIImage* image = ....
NSString* blogName = ....

NSData* imageData  = UIImageJPEGRepresentation(image, 1);
NSDictionary* parameters   = @{@"caption": @"caption text"};
NSArray* fileNameArray  = @["image.jpg"];
NSArray* imageDataArray = @[imageData];

 [[TMAPIClient sharedInstance] photo:blogName imageNSDataArray:imageDataArray contentTypeArray:contentTypeArray fileNameArray:fileNameArray parameters:parameters callback:^(id response, NSError *error) {
        [_shareItems.sharePanel didShareToPlatform:self withError:error];
           if (error)
               NSLog(@"error: %@", error);

    }];


```
