### PR TITLE
Suppress Deprecation Warning

### DIFF
--- a/TMTumblrSDK/Authentication/TMOAuth.m
+++ b/TMTumblrSDK/Authentication/TMOAuth.m
@@ -103,7 +103,10 @@ NSString *sign(NSString *baseString, NSString *consumerSecret, NSString *tokenSe
     if ([hashedData respondsToSelector:@selector(base64EncodedStringWithOptions:)]) {
         base64EncodedString = [hashedData base64EncodedStringWithOptions:0];
     } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         base64EncodedString = [hashedData base64Encoding];
+#pragma clang diagnostic pop
     }
     
     return base64EncodedString;


### PR DESCRIPTION
Suppresses this warning:

‘base64Encoding’ is deprecated: first deprecated in iOS 7.0