### PR TITLE
Use SSL for requesting a token

### DIFF
--- a/TMTumblrSDK/Authentication/TMTumblrAuthenticator.m
+++ b/TMTumblrSDK/Authentication/TMTumblrAuthenticator.m
@@ -48,7 +48,7 @@ NSDictionary *formEncodedDataToDictionary(NSData *data);
     // Clear token secret in case authentication was previously started but not finished
     self.threeLeggedOAuthTokenSecret = nil;
     
-    NSString *tokenRequestURLString = [NSString stringWithFormat:@"http://www.tumblr.com/oauth/request_token?oauth_callback=%@",
+    NSString *tokenRequestURLString = [NSString stringWithFormat:@"https://www.tumblr.com/oauth/request_token?oauth_callback=%@",
                                        TMURLEncode([NSString stringWithFormat:@"%@://tumblr-authorize", URLScheme])];
     
     NSMutableURLRequest *request = mutableRequestWithURLString(tokenRequestURLString);


### PR DESCRIPTION
Requesting without SSL would sometimes return a 401

This is an extension of 8936e1528c61ff8d159f67b8196e608553ca1e3a