### PR TITLE
Add photo post URL documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,9 @@ tumblr://x-callback-url/text?title=Title&body=Body&tags=gif&tags=lol
 tumblr://x-callback-url/quote?quote=Quote&source=Source
 tumblr://x-callback-url/link?title=Bryan&url=bryan.io&description=Website
 tumblr://x-callback-url/chat?title=Title&body=Body&tags=gif&tags=lol
+
+// Will create a post using images from `[UIPasteboard generalPasteboard].images`
+tumblr://x-callback-url/photo?caption=Caption&tags=gif&tags=lol
 ```
 
 If you don't want to use this SDK and would rather hit these URLs directly, please go

--- a/TMTumblrSDK.podspec.json
+++ b/TMTumblrSDK.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "TMTumblrSDK",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "summary": "An unopinionated and flexible library for easily integrating Tumblr data into your iOS or OS X application.",
   "authors": {
     "Bryan Irace": "bryan@tumblr.com"
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/tumblr/TMTumblrSDK.git",
-    "tag": "2.1.3"
+    "tag": "2.2.0"
   },
   "requires_arc": true,
   "platforms": {


### PR DESCRIPTION
Add documentation for the new route that allows third-party applications to create photo posts from pasteboard data.