### PR TITLE
Add Proper Module Support

### DIFF
--- a/TMTumblrSDK.podspec.json
+++ b/TMTumblrSDK.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "TMTumblrSDK",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "summary": "An unopinionated and flexible library for easily integrating Tumblr data into your iOS or OS X application.",
   "authors": {
     "Bryan Irace": "bryan@tumblr.com"
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/tumblr/TMTumblrSDK.git",
-    "tag": "2.2.0"
+    "tag": "3.0.0"
   },
   "requires_arc": true,
   "platforms": {

--- a/TMTumblrSDK/APIClient/TMAPIClient.h
+++ b/TMTumblrSDK/APIClient/TMAPIClient.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2013 Tumblr. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import JXHTTP;
+#else
 #import <JXHTTP/JXHTTP.h>
+#endif
 
 typedef void (^TMAPICallback)(id, NSError *error);
 

--- a/TMTumblrSDK/APIClient/TMAPIClient.h
+++ b/TMTumblrSDK/APIClient/TMAPIClient.h
@@ -6,18 +6,8 @@
 //  Copyright (c) 2013 Tumblr. All rights reserved.
 //
 
-/*
- *  We use the presence of a wrapper extension to determine if the pod is being built as a framework target
- *  or a static library, because static libraries do not have a wrapper extension.
- *
- *  See: The WRAPPER_EXTENSION documentation here:
- *  https://developer.apple.com/library/ios/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html
- */
-#if WRAPPER_EXTENSION
-@import JXHTTP;
-#else
-#import <JXHTTP/JXHTTP.h>
-#endif
+@class JXHTTPOperation;
+@class JXHTTPOperationQueue;
 
 typedef void (^TMAPICallback)(id, NSError *error);
 

--- a/TMTumblrSDK/APIClient/TMAPIClient.h
+++ b/TMTumblrSDK/APIClient/TMAPIClient.h
@@ -6,7 +6,14 @@
 //  Copyright (c) 2013 Tumblr. All rights reserved.
 //
 
-#if __has_feature(modules)
+/*
+ *  We use the presence of a wrapper extension to determine if the pod is being built as a framework target
+ *  or a static library.
+ *
+ *  See: The WRAPPER_EXTENSION documentation here:
+ *  https://developer.apple.com/library/ios/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html
+ */
+#if WRAPPER_EXTENSION
 @import JXHTTP;
 #else
 #import <JXHTTP/JXHTTP.h>

--- a/TMTumblrSDK/APIClient/TMAPIClient.h
+++ b/TMTumblrSDK/APIClient/TMAPIClient.h
@@ -8,7 +8,7 @@
 
 /*
  *  We use the presence of a wrapper extension to determine if the pod is being built as a framework target
- *  or a static library.
+ *  or a static library, because static libraries do not have a wrapper extension.
  *
  *  See: The WRAPPER_EXTENSION documentation here:
  *  https://developer.apple.com/library/ios/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html

--- a/TMTumblrSDK/APIClient/TMAPIClient.m
+++ b/TMTumblrSDK/APIClient/TMAPIClient.m
@@ -8,11 +8,11 @@
 
 #import "TMAPIClient.h"
 
+#import <JXHTTP/JXHTTP.h>
+
 #import "TMOAuth.h"
 #import "TMSDKUserAgent.h"
 #import "TMTumblrAuthenticator.h"
-
-#import <JXHTTP/JXHTTP.h>
 
 static NSTimeInterval const TMAPIClientDefaultRequestTimeoutInterval = 60;
 

--- a/TMTumblrSDK/APIClient/TMAPIClient.m
+++ b/TMTumblrSDK/APIClient/TMAPIClient.m
@@ -12,6 +12,8 @@
 #import "TMSDKUserAgent.h"
 #import "TMTumblrAuthenticator.h"
 
+#import <JXHTTP/JXHTTP.h>
+
 static NSTimeInterval const TMAPIClientDefaultRequestTimeoutInterval = 60;
 
 @interface TMAPIClient()


### PR DESCRIPTION
Although `TMTumblrSDK` compiles as a framework, it exposes the umbrella header for `JXHTTP`. This isn’t the right behavior, and it causes a few issues when attempting to debug Swift code.