### PR TITLE
Modify Podfiles for example projects

### DIFF
--- a/Examples/AppClientExample/Podfile
+++ b/Examples/AppClientExample/Podfile
@@ -1,3 +1,3 @@
 platform :ios, '5.0'
 
-pod 'TMTumblrSDK/AppClient', :local => '../..'
+pod 'TMTumblrSDK/AppClient', :path => '../..'

--- a/Examples/PhotoPostExample/Podfile
+++ b/Examples/PhotoPostExample/Podfile
@@ -1,3 +1,3 @@
 platform :ios, '5.0'
 
-pod 'TMTumblrSDK/APIClient', :local => '../..'
+pod 'TMTumblrSDK/APIClient', :path => '../..'


### PR DESCRIPTION
Modify Podfile to remove following error message in 'pod install'
'[!] The `:local` option of the Podfile has been renamed to `:path` and it is deprecated.'