### PR TITLE
Expose constants for syndication deep link parameter keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,12 @@ handle callbacks from this flow.
 If you're only interested in the app client,
 the `TMTumblrSDK/AppClient` sub-pod can be installed by itself.
 
+#### Attribution and Deep Links
+
+If your app posts to Tumblr, you can provide the API Client with deep link URLs under the keys `TMPostKeyDeepLinkiOS` and `TMPostKeyDeepLinkAndroid`. This will cause attribution UI for your app to be displayed beneath the post on the respective platform. When this UI is tapped, the OS will open the deep link you specified. Be aware that all icons and required fields must be provided in your app's [configuration](https://www.tumblr.com/oauth/apps) before this UI will be visible.
+
+**NOTE:** This is currently only available to whitelisted app partners. Contact Tumblr business development ([bd@tumblr.com](mailto:bd@tumblr.com)) if your app requires this functionality.
+
 #### URL schemes
 
 Tumblr for iOS exposes actions using the [x-callback-url](http://x-callback-url.com/)

--- a/TMTumblrSDK/APIClient/TMAPIClient.h
+++ b/TMTumblrSDK/APIClient/TMAPIClient.h
@@ -13,6 +13,24 @@
 typedef void (^TMAPICallback)(id, NSError *error);
 
 /**
+ *  Key for a URL string representing a deep link into your iOS app. If a value is set for this key in the parameters of a post request,
+ *  the Tumblr iOS app will display an app attribution bar at the bottom of the post that is created. If your app is installed, tapping
+ *  this bar or the "Open" button will redirect the user to the URL specified. If your app is not installed, they will be redirected to
+ *  your app's page on the app store.
+ *  @warning You must provide a valid App Store URL for your application on the configuration page, or the attribution
+ *  bar UI will not be displayed on posts.
+ */
+extern NSString * const TMPostKeyDeepLinkiOS;
+
+/**
+ *  Key for a URL string representing a deep link into your Android app. If a value is set for this key in the parameters of a post request,
+ *  the Tumblr Android app will display an app attribution bar at the bottom of the post that is created. If your app is installed, tapping
+ *  this bar or the "Open" button will redirect the user to the URL specified. If your app is not installed, they will be redirected to your
+ *  app's Google Play Store URL, or your Application Website if a Google Play Store URL has not been provided.
+ */
+extern NSString * const TMPostKeyDeepLinkAndroid;
+
+/**
  Full wrapper around the [Tumblr API](http://www.tumblr.com/docs/en/api/). Please see API documentation for a listing 
  of each route's parameters.
  */

--- a/TMTumblrSDK/APIClient/TMAPIClient.m
+++ b/TMTumblrSDK/APIClient/TMAPIClient.m
@@ -16,6 +16,9 @@
 
 static NSTimeInterval const TMAPIClientDefaultRequestTimeoutInterval = 60;
 
+NSString * const TMPostKeyDeepLinkiOS = @"deep_link_ios";
+NSString * const TMPostKeyDeepLinkAndroid = @"deep_link_android";
+
 @interface TMAPIClient()
 
 @property (nonatomic, strong) JXHTTPOperationQueue *queue;


### PR DESCRIPTION
This makes it easier for partners to improve their in-app sharing experiences by deep linking from Tumblr back into their app.