### PR TITLE
Remove appendpath call

### DIFF
--- a/Classes/TMRequest/TMAPIRequest.m
+++ b/Classes/TMRequest/TMAPIRequest.m
@@ -118,7 +118,9 @@
 }
 
 - (nonnull NSURL *)URL {
-    NSURL *URL = [self.baseURL URLByAppendingPathComponent:self.path];
+    NSString *baseURLString = self.baseURL.absoluteString;
+    NSString *baseURLStringPlusPath = [baseURLString stringByAppendingString:self.path];
+    NSURL *URL = [NSURL URLWithString:baseURLStringPlusPath];
 
     if (!URL) {
         @throw [[NSException alloc] initWithName:@"Illegal URL or Path exception" reason:@"The URL generated was nil." userInfo:nil];

--- a/ExampleiOS/ExampleiOSTests/TMRequestFactoryTests.m
+++ b/ExampleiOS/ExampleiOSTests/TMRequestFactoryTests.m
@@ -23,4 +23,84 @@
     XCTAssert(request.method == TMHTTPRequestMethodPOST);
 }
 
+- (void)testURLEncodingSimplePath {
+    TMRequestFactory *requestFactory = [[TMRequestFactory alloc] initWithBaseURLDeterminer:[[TMBasicBaseURLDeterminer alloc] init]];
+
+    id <TMRequest> request = [requestFactory requestWithPath:[NSString stringWithFormat:@"samplePathComponent1/samplePathComponent2/%@", @"simpleString"] method:TMHTTPRequestMethodGET queryParameters:nil];
+
+    XCTAssert([request.URL.absoluteString isEqualToString:@"https://api.tumblr.com/v2/samplePathComponent1/samplePathComponent2/simpleString"]);
+}
+
+- (void)testURLEncodingQuestionCharacterInPath {
+    TMRequestFactory *requestFactory = [[TMRequestFactory alloc] initWithBaseURLDeterminer:[[TMBasicBaseURLDeterminer alloc] init]];
+
+    id <TMRequest> request = [requestFactory requestWithPath:[NSString stringWithFormat:@"samplePathComponent1/samplePathComponent2/%@", TMURLEncode(@"didithappen?")] method:TMHTTPRequestMethodGET queryParameters:nil];
+
+    XCTAssert([request.URL.absoluteString isEqualToString:@"https://api.tumblr.com/v2/samplePathComponent1/samplePathComponent2/didithappen%3F"]);
+}
+
+- (void)testURLEncodingSpaceCharactersInPath {
+    TMRequestFactory *requestFactory = [[TMRequestFactory alloc] initWithBaseURLDeterminer:[[TMBasicBaseURLDeterminer alloc] init]];
+
+    id <TMRequest> request = [requestFactory requestWithPath:[NSString stringWithFormat:@"samplePathComponent1/samplePathComponent2/%@", TMURLEncode(@"hat cat in ")] method:TMHTTPRequestMethodGET queryParameters:nil];
+
+    XCTAssert([request.URL.absoluteString isEqualToString:@"https://api.tumblr.com/v2/samplePathComponent1/samplePathComponent2/hat%20cat%20in%20"]);
+}
+
+- (void)testURLEncodingHashCharactersInPath {
+    TMRequestFactory *requestFactory = [[TMRequestFactory alloc] initWithBaseURLDeterminer:[[TMBasicBaseURLDeterminer alloc] init]];
+
+    id <TMRequest> request = [requestFactory requestWithPath:[NSString stringWithFormat:@"samplePathComponent1/samplePathComponent2/%@", TMURLEncode(@"maybeATag#tag")] method:TMHTTPRequestMethodGET queryParameters:nil];
+
+    XCTAssert([request.URL.absoluteString isEqualToString:@"https://api.tumblr.com/v2/samplePathComponent1/samplePathComponent2/maybeATag%23tag"]);
+}
+
+- (void)testURLEncodingPlusCharactersInPath {
+    TMRequestFactory *requestFactory = [[TMRequestFactory alloc] initWithBaseURLDeterminer:[[TMBasicBaseURLDeterminer alloc] init]];
+
+    id <TMRequest> request = [requestFactory requestWithPath:[NSString stringWithFormat:@"samplePathComponent1/samplePathComponent2/%@", TMURLEncode(@"who+why")] method:TMHTTPRequestMethodGET queryParameters:nil];
+
+    XCTAssert([request.URL.absoluteString isEqualToString:@"https://api.tumblr.com/v2/samplePathComponent1/samplePathComponent2/who%2Bwhy"]);
+}
+
+- (void)testURLEncodingEqualCharactersInPath {
+    TMRequestFactory *requestFactory = [[TMRequestFactory alloc] initWithBaseURLDeterminer:[[TMBasicBaseURLDeterminer alloc] init]];
+
+    id <TMRequest> request = [requestFactory requestWithPath:[NSString stringWithFormat:@"samplePathComponent1/samplePathComponent2/%@", TMURLEncode(@"hat=cat")] method:TMHTTPRequestMethodGET queryParameters:nil];
+
+    XCTAssert([request.URL.absoluteString isEqualToString:@"https://api.tumblr.com/v2/samplePathComponent1/samplePathComponent2/hat%3Dcat"]);
+}
+
+- (void)testURLEncodingForwardSlashCharactersInPath {
+    TMRequestFactory *requestFactory = [[TMRequestFactory alloc] initWithBaseURLDeterminer:[[TMBasicBaseURLDeterminer alloc] init]];
+
+    id <TMRequest> request = [requestFactory requestWithPath:[NSString stringWithFormat:@"samplePathComponent1/samplePathComponent2/%@", TMURLEncode(@"hat/cat")] method:TMHTTPRequestMethodGET queryParameters:nil];
+
+    XCTAssert([request.URL.absoluteString isEqualToString:@"https://api.tumblr.com/v2/samplePathComponent1/samplePathComponent2/hat%2Fcat"]);
+}
+
+- (void)testURLEncodingBackwardSlashCharactersInPath {
+    TMRequestFactory *requestFactory = [[TMRequestFactory alloc] initWithBaseURLDeterminer:[[TMBasicBaseURLDeterminer alloc] init]];
+
+    id <TMRequest> request = [requestFactory requestWithPath:[NSString stringWithFormat:@"samplePathComponent1/samplePathComponent2/%@", TMURLEncode(@"hat\\cat")] method:TMHTTPRequestMethodGET queryParameters:nil];
+
+    XCTAssert([request.URL.absoluteString isEqualToString:@"https://api.tumblr.com/v2/samplePathComponent1/samplePathComponent2/hat%5Ccat"]);
+}
+
+- (void)testURLEncodingAllSpecialCharactersInPathInLastPositionInPath {
+    TMRequestFactory *requestFactory = [[TMRequestFactory alloc] initWithBaseURLDeterminer:[[TMBasicBaseURLDeterminer alloc] init]];
+
+    id <TMRequest> request = [requestFactory requestWithPath:[NSString stringWithFormat:@"samplePathComponent1/samplePathComponent2/%@", TMURLEncode(@"ij#ij+ij/ij/ij+=?\\")] method:TMHTTPRequestMethodGET queryParameters:nil];
+
+    XCTAssert([request.URL.absoluteString isEqualToString:@"https://api.tumblr.com/v2/samplePathComponent1/samplePathComponent2/ij%23ij%2Bij%2Fij%2Fij%2B%3D%3F%5C"]);
+}
+
+- (void)testURLEncodingAllSpecialCharactersInPathInMiddlePositionInPath {
+    TMRequestFactory *requestFactory = [[TMRequestFactory alloc] initWithBaseURLDeterminer:[[TMBasicBaseURLDeterminer alloc] init]];
+
+    id <TMRequest> request = [requestFactory requestWithPath:[NSString stringWithFormat:@"samplePathComponent1/samplePathComponent2/%@/samplePathComponent3", TMURLEncode(@"ij#ij+ij/ij/ij+=?\\")] method:TMHTTPRequestMethodGET queryParameters:nil];
+
+    XCTAssert([request.URL.absoluteString isEqualToString:@"https://api.tumblr.com/v2/samplePathComponent1/samplePathComponent2/ij%23ij%2Bij%2Fij%2Fij%2B%3D%3F%5C/samplePathComponent3"]);
+}
+
 @end


### PR DESCRIPTION
`URLByAppendingPathComponent` is doing some percent encoding that is resulting in double encoding for some characters in path parameters that have been previously encoded. This removes that api in favor of the simpler string appending one.