### PR TITLE
Sign URL with query component double encoding

### DIFF
--- a/Classes/Auth/TMOAuth.h
+++ b/Classes/Auth/TMOAuth.h
@@ -61,14 +61,14 @@ __attribute__((objc_subclassing_restricted))
  @param tokenSecret OAuth user secret
  @param timestamp Unix / epoch time
  */
-+ (NSString *)signUrlWithQueryComponent:(NSURL *)URL
-                                 method:(NSString *)method
-                         postParameters:(NSDictionary *)postParameters
-                                  nonce:(NSString *)nonce
-                            consumerKey:(NSString *)consumerKey
-                         consumerSecret:(NSString *)consumerSecret
-                                  token:(NSString *)token
-                            tokenSecret:(NSString *)tokenSecret
-                              timestamp:(NSString *)timestamp;
++ (NSURL *)signUrlWithQueryComponent:(NSURL *)URL
+                              method:(NSString *)method
+                      postParameters:(NSDictionary *)postParameters
+                               nonce:(NSString *)nonce
+                         consumerKey:(NSString *)consumerKey
+                      consumerSecret:(NSString *)consumerSecret
+                               token:(NSString *)token
+                         tokenSecret:(NSString *)tokenSecret
+                           timestamp:(NSString *)timestamp;
 
 @end

--- a/Classes/Auth/TMOAuth.h
+++ b/Classes/Auth/TMOAuth.h
@@ -61,14 +61,14 @@ __attribute__((objc_subclassing_restricted))
  @param tokenSecret OAuth user secret
  @param timestamp Unix / epoch time
  */
-+ (NSURL *)signUrlWithQueryComponent:(NSURL *)URL
-                              method:(NSString *)method
-                      postParameters:(NSDictionary *)postParameters
-                               nonce:(NSString *)nonce
-                         consumerKey:(NSString *)consumerKey
-                      consumerSecret:(NSString *)consumerSecret
-                               token:(NSString *)token
-                         tokenSecret:(NSString *)tokenSecret
-                           timestamp:(NSString *)timestamp;
++ (NSString *)signUrlWithQueryComponent:(NSURL *)URL
+                                 method:(NSString *)method
+                         postParameters:(NSDictionary *)postParameters
+                                  nonce:(NSString *)nonce
+                            consumerKey:(NSString *)consumerKey
+                         consumerSecret:(NSString *)consumerSecret
+                                  token:(NSString *)token
+                            tokenSecret:(NSString *)tokenSecret
+                              timestamp:(NSString *)timestamp;
 
 @end

--- a/Classes/Auth/TMOAuth.m
+++ b/Classes/Auth/TMOAuth.m
@@ -12,6 +12,7 @@
 #import <CommonCrypto/CommonHMAC.h>
 #import <sys/sysctl.h>
 #import "TMSDKFunctions.h"
+#import "TMURLEncoding.h"
 
 @interface TMOAuth()
 
@@ -51,15 +52,15 @@ NSData *HMACSHA1(NSString *dataString, NSString *keyString);
     return auth.headerString;
 }
 
-+ (NSURL *)signUrlWithQueryComponent:(NSURL *)URL
-                              method:(NSString *)method
-                      postParameters:(NSDictionary *)postParameters
-                               nonce:(NSString *)nonce
-                         consumerKey:(NSString *)consumerKey
-                      consumerSecret:(NSString *)consumerSecret
-                               token:(NSString *)token
-                         tokenSecret:(NSString *)tokenSecret
-                           timestamp:(NSString *)timestamp {
++ (NSString *)signUrlWithQueryComponent:(NSURL *)URL
+                                 method:(NSString *)method
+                         postParameters:(NSDictionary *)postParameters
+                                  nonce:(NSString *)nonce
+                            consumerKey:(NSString *)consumerKey
+                         consumerSecret:(NSString *)consumerSecret
+                                  token:(NSString *)token
+                            tokenSecret:(NSString *)tokenSecret
+                              timestamp:(NSString *)timestamp {
 
     NSMutableDictionary *oAuthParameters = [TMOAuth OAuthParametersFromURL:nil
                                                                        url: URL
@@ -71,16 +72,7 @@ NSData *HMACSHA1(NSString *dataString, NSString *keyString);
                                                                      token: token
                                                                tokenSecret: tokenSecret
                                                                  timestamp: timestamp];
-    
-    NSMutableArray *queryItems = [NSMutableArray array];
-    for (NSString *key in oAuthParameters) {
-        [queryItems addObject:[NSURLQueryItem queryItemWithName:key value:TMURLEncode(oAuthParameters[key])]];
-    }
-
-    NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithURL:URL resolvingAgainstBaseURL:true];
-    urlComponents.queryItems = queryItems;
-
-    return [urlComponents URL];
+    return [URL.absoluteString stringByAppendingFormat:@"?%@", [TMURLEncoding encodedDictionary:oAuthParameters]];
 }
 
 - (id)initWithURL:(NSURL *)URL

--- a/Classes/Auth/TMOAuth.m
+++ b/Classes/Auth/TMOAuth.m
@@ -52,15 +52,15 @@ NSData *HMACSHA1(NSString *dataString, NSString *keyString);
     return auth.headerString;
 }
 
-+ (NSString *)signUrlWithQueryComponent:(NSURL *)URL
-                                 method:(NSString *)method
-                         postParameters:(NSDictionary *)postParameters
-                                  nonce:(NSString *)nonce
-                            consumerKey:(NSString *)consumerKey
-                         consumerSecret:(NSString *)consumerSecret
-                                  token:(NSString *)token
-                            tokenSecret:(NSString *)tokenSecret
-                              timestamp:(NSString *)timestamp {
++ (NSURL *)signUrlWithQueryComponent:(NSURL *)URL
+                              method:(NSString *)method
+                      postParameters:(NSDictionary *)postParameters
+                               nonce:(NSString *)nonce
+                         consumerKey:(NSString *)consumerKey
+                      consumerSecret:(NSString *)consumerSecret
+                               token:(NSString *)token
+                         tokenSecret:(NSString *)tokenSecret
+                           timestamp:(NSString *)timestamp {
 
     NSMutableDictionary *oAuthParameters = [TMOAuth OAuthParametersFromURL:nil
                                                                        url: URL
@@ -72,7 +72,7 @@ NSData *HMACSHA1(NSString *dataString, NSString *keyString);
                                                                      token: token
                                                                tokenSecret: tokenSecret
                                                                  timestamp: timestamp];
-    return [URL.absoluteString stringByAppendingFormat:@"?%@", [TMURLEncoding encodedDictionary:oAuthParameters]];
+    return [NSURL URLWithString:[URL.absoluteString stringByAppendingFormat:@"?%@", [TMURLEncoding encodedDictionary:oAuthParameters]]];
 }
 
 - (id)initWithURL:(NSURL *)URL

--- a/ExampleiOS/ExampleiOSTests/TMOAuthTests.m
+++ b/ExampleiOS/ExampleiOSTests/TMOAuthTests.m
@@ -16,22 +16,16 @@
 @implementation TMOAuthTests
 
 - (void)testSignUrlWithQueryComponentCalculatesProperSignature {
-    NSString *signedURL = [TMOAuth signUrlWithQueryComponent:[NSURL URLWithString:@"https://tumblr.com/"]
-                                                      method:@"GET"
-                                              postParameters:[NSDictionary dictionary]
-                                                       nonce:@"1234"
-                                                 consumerKey:@"consumerKey"
-                                              consumerSecret:@"consumerSecret"
-                                                       token:@"token"
-                                                 tokenSecret:@"tokenSecret"
-                                                   timestamp:@"1511967770"];
-    
-    NSURLComponents *urlComponents = [NSURLComponents componentsWithString:signedURL];
-    NSArray *queryItems = urlComponents.queryItems;
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"name=%@", @"oauth_signature"];
-    NSURLQueryItem *queryItem = [queryItems filteredArrayUsingPredicate:predicate].firstObject;
-    
-    XCTAssert([queryItem.value isEqualToString:@"w/LP1MdJwiCfakR3GbW9IoeOz1E="], @"The generated OAuth signature should match the expected value.");
+    NSURL *signedURL = [TMOAuth signUrlWithQueryComponent:[NSURL URLWithString:@"https://tumblr.com/"]
+                                                   method:@"GET"
+                                           postParameters:[NSDictionary dictionary]
+                                                    nonce:@"1234"
+                                              consumerKey:@"consumerKey"
+                                           consumerSecret:@"consumerSecret"
+                                                    token:@"token"
+                                              tokenSecret:@"tokenSecret"
+                                                timestamp:@"1511967770"];
+    XCTAssert([signedURL.absoluteString isEqualToString:@"https://tumblr.com/?oauth_consumer_key=consumerKey&oauth_nonce=1234&oauth_signature=w/LP1MdJwiCfakR3GbW9IoeOz1E%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1511967770&oauth_token=token&oauth_version=1.0"], @"The generated OAuth signature should match the expected value.");
 }
 
 - (void)testInitSetsInstanceVariables {

--- a/ExampleiOS/ExampleiOSTests/TMOAuthTests.m
+++ b/ExampleiOS/ExampleiOSTests/TMOAuthTests.m
@@ -16,22 +16,22 @@
 @implementation TMOAuthTests
 
 - (void)testSignUrlWithQueryComponentCalculatesProperSignature {
-    NSURL *signedURL = [TMOAuth signUrlWithQueryComponent:[NSURL URLWithString:@"https://tumblr.com/"]
-                                                   method:@"GET"
-                                           postParameters:[NSDictionary dictionary]
-                                                    nonce:@"1234"
-                                              consumerKey:@"consumerKey"
-                                           consumerSecret:@"consumerSecret"
-                                                    token:@"token"
-                                              tokenSecret:@"tokenSecret"
-                                                timestamp:@"1511967770"];
+    NSString *signedURL = [TMOAuth signUrlWithQueryComponent:[NSURL URLWithString:@"https://tumblr.com/"]
+                                                      method:@"GET"
+                                              postParameters:[NSDictionary dictionary]
+                                                       nonce:@"1234"
+                                                 consumerKey:@"consumerKey"
+                                              consumerSecret:@"consumerSecret"
+                                                       token:@"token"
+                                                 tokenSecret:@"tokenSecret"
+                                                   timestamp:@"1511967770"];
     
-    NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:signedURL resolvingAgainstBaseURL:false];
+    NSURLComponents *urlComponents = [NSURLComponents componentsWithString:signedURL];
     NSArray *queryItems = urlComponents.queryItems;
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"name=%@", @"oauth_signature"];
     NSURLQueryItem *queryItem = [queryItems filteredArrayUsingPredicate:predicate].firstObject;
     
-    XCTAssert([queryItem.value isEqualToString:@"w%2FLP1MdJwiCfakR3GbW9IoeOz1E%3D"], @"The generated OAuth signature should match the expected value.");
+    XCTAssert([queryItem.value isEqualToString:@"w/LP1MdJwiCfakR3GbW9IoeOz1E="], @"The generated OAuth signature should match the expected value.");
 }
 
 - (void)testInitSetsInstanceVariables {


### PR DESCRIPTION
What
---
Setting `NSURLComponents#queryItems` was causing a second layer of encoding on the query items. This changes the function to return a string, and use `TMURLEncoding` to handle encoding the query items. This does not change behavior for signing a request with an OAuth header.

Testing
---
- [ ] Ensure `TMOauthTests` succeeds

@Pearapps @ndis1 