### PR TITLE
Adjusting Network Speed tracker 

### DIFF
--- a/Classes/Networking/TMConcreteURLSessionTaskDelegate.m
+++ b/Classes/Networking/TMConcreteURLSessionTaskDelegate.m
@@ -47,7 +47,7 @@
     for (NSURLSessionTaskTransactionMetrics *metric in metrics.transactionMetrics) {
         if (metric.resourceFetchType == NSURLSessionTaskMetricsResourceFetchTypeNetworkLoad) {
 
-            [self.networkSpeedTracker track:metric.responseStartDate endDate:metric.responseEndDate bytes:task.countOfBytesReceived];
+            [self.networkSpeedTracker track:metric.requestStartDate endDate:metric.responseEndDate bytes:task.countOfBytesReceived];
 
         }
     }

--- a/Classes/Networking/TMNetworkSpeedQuality.h
+++ b/Classes/Networking/TMNetworkSpeedQuality.h
@@ -13,5 +13,6 @@ typedef NS_ENUM(NSInteger, TMNetworkSpeedQuality) {
     TMNetworkSpeedQualityUnkown = 0,
     TMNetworkSpeedQualityBad = 1,
     TMNetworkSpeedQualityModerate = 2,
-    TMNetworkSpeedQualityGood = 3
+    TMNetworkSpeedQualityGood = 3,
+    TMNetworkSpeedQualityExcellent = 4
 };

--- a/Classes/Networking/TMNetworkSpeedTracker.m
+++ b/Classes/Networking/TMNetworkSpeedTracker.m
@@ -24,7 +24,7 @@ const short targetSampleSize = 10;
 }
 
 - (void)track:(NSDate *)start endDate:(NSDate *)end bytes:(long long)bytes {
-    if (bytes >= 1024) {
+    if (bytes >= 10240) {
         const NSTimeInterval timeDifference = end.timeIntervalSinceReferenceDate - start.timeIntervalSinceReferenceDate;
 
         if (timeDifference > 0.05) {

--- a/Classes/Networking/TMNetworkSpeedTracker.m
+++ b/Classes/Networking/TMNetworkSpeedTracker.m
@@ -27,7 +27,7 @@ const short targetSampleSize = 10;
     if (bytes >= 1024) {
         const NSTimeInterval timeDifference = end.timeIntervalSinceReferenceDate - start.timeIntervalSinceReferenceDate;
 
-        if (timeDifference > 0) {
+        if (timeDifference > 0.05) {
             const double bytesPerSecond = bytes / timeDifference;
             NSNumber * const kbps = @(bytesPerSecond * 0.008);
             const id class = [self class];

--- a/Classes/Networking/TMNetworkSpeedTracker.m
+++ b/Classes/Networking/TMNetworkSpeedTracker.m
@@ -27,7 +27,7 @@ const short targetSampleSize = 10;
     if (bytes >= 1024) {
         const NSTimeInterval timeDifference = end.timeIntervalSinceReferenceDate - start.timeIntervalSinceReferenceDate;
 
-        if (timeDifference > 0.02) {
+        if (timeDifference > 0.05) {
             const double bytesPerSecond = bytes / timeDifference;
             NSNumber * const kbps = @(bytesPerSecond * 0.008);
             const id class = [self class];

--- a/Classes/Networking/TMNetworkSpeedTracker.m
+++ b/Classes/Networking/TMNetworkSpeedTracker.m
@@ -27,7 +27,7 @@ const short targetSampleSize = 10;
     if (bytes >= 10240) {
         const NSTimeInterval timeDifference = end.timeIntervalSinceReferenceDate - start.timeIntervalSinceReferenceDate;
 
-        if (timeDifference > 0.05) {
+        if (timeDifference > 0.001) {
             const double bytesPerSecond = bytes / timeDifference;
             NSNumber * const kbps = @(bytesPerSecond * 0.008);
             const id class = [self class];

--- a/Classes/Networking/TMNetworkSpeedTracker.m
+++ b/Classes/Networking/TMNetworkSpeedTracker.m
@@ -27,7 +27,7 @@ const short targetSampleSize = 10;
     if (bytes >= 1024) {
         const NSTimeInterval timeDifference = end.timeIntervalSinceReferenceDate - start.timeIntervalSinceReferenceDate;
 
-        if (timeDifference > 0.05) {
+        if (timeDifference > 0.02) {
             const double bytesPerSecond = bytes / timeDifference;
             NSNumber * const kbps = @(bytesPerSecond * 0.008);
             const id class = [self class];
@@ -43,6 +43,7 @@ const short targetSampleSize = 10;
     const double kbps = [self kbps];
     const short bad = 150;
     const short moderate = 550;
+    const short good = 2000;
 
     if (kbps <= 0) {
         return TMNetworkSpeedQualityUnkown;
@@ -53,8 +54,11 @@ const short targetSampleSize = 10;
     else if (kbps <= moderate) {
         return TMNetworkSpeedQualityModerate;
     }
-    else {
+    else if (kbps <= good) {
         return TMNetworkSpeedQualityGood;
+    }
+    else {
+        return TMNetworkSpeedQualityExcellent;
     }
 }
 

--- a/ExampleiOS/ExampleiOSTests/TMNetworkSpeedTrackerTests.m
+++ b/ExampleiOS/ExampleiOSTests/TMNetworkSpeedTrackerTests.m
@@ -55,8 +55,8 @@
 
 // Number of bytes transferred in a mock response
 const short tinyPayload = 10;
-const short oneKBPayload = 1024;
-const short badStatePayload = 18750;
+const short tenKbPayload = 10240;
+const int badStatePayload = 18750;
 const int moderateStatePayload = 68750;
 const int goodStatePayload = 250000;
 const int excellentStatePayload = 250001;
@@ -80,18 +80,18 @@ const float timeInterval = 1.0;
     XCTAssertEqual([TestableEmptyTMNetworkSpeedTracker quality], TMNetworkSpeedQualityUnkown,
                    "Quality was tracked when a series of requests smaller than the trackable payload size were received.");
 
-    [testEmptyTracker track:start endDate:endDate bytes:oneKBPayload];
+    [testEmptyTracker track:start endDate:endDate bytes:tenKbPayload];
     XCTAssertEqual([TestableEmptyTMNetworkSpeedTracker quality], TMNetworkSpeedQualityUnkown,
                    "Received a network quality other than 'unknown' with only one tracked network speed rate.");
 
     // The tracker should only send back a state other than "Unknown" when it receives 10 requests.
     for (int i = 0; i < 8; i++) {
-        [testEmptyTracker track:start endDate:endDate bytes:oneKBPayload];
+        [testEmptyTracker track:start endDate:endDate bytes:tenKbPayload];
     }
     XCTAssertEqual([TestableEmptyTMNetworkSpeedTracker quality], TMNetworkSpeedQualityUnkown,
                    "After receiving at 9 requests that are 1 KB in size, the tracker sending back a quality other than 'Unknown'.");
 
-    [testEmptyTracker track:start endDate:endDate bytes:oneKBPayload];
+    [testEmptyTracker track:start endDate:endDate bytes:tenKbPayload];
     XCTAssertNotEqual([TestableEmptyTMNetworkSpeedTracker quality], TMNetworkSpeedQualityUnkown,
                       "After receiving at 10 requests that are 1 KB in size, the tracker sending back an 'Unknown' network quality.");
 }

--- a/ExampleiOS/ExampleiOSTests/TMNetworkSpeedTrackerTests.m
+++ b/ExampleiOS/ExampleiOSTests/TMNetworkSpeedTrackerTests.m
@@ -58,7 +58,8 @@ const short tinyPayload = 10;
 const short oneKBPayload = 1024;
 const short badStatePayload = 18750;
 const int moderateStatePayload = 68750;
-const int goodStatePayload = 68751;
+const int goodStatePayload = 250000;
+const int excellentStatePayload = 250001;
 
 // Time interval for transfers
 const float timeInterval = 1.0;
@@ -131,7 +132,20 @@ const float timeInterval = 1.0;
     }
 
     XCTAssertEqual([TestableTMNetworkSpeedTracker quality], TMNetworkSpeedQualityGood,
-                   "> 550 kbps was not rated as 'Good'.");
+                   "2000 kbps was not rated as 'Good'.");
+}
+
+- (void)testExcellentQualityState {
+    TMNetworkSpeedTracker *testTracker = [[TestableTMNetworkSpeedTracker alloc] init];
+    NSDate* start = [NSDate date];
+    NSDate* endDate = [NSDate dateWithTimeInterval:timeInterval sinceDate:start];
+
+    for (int i = 0; i < 10; i++) {
+        [testTracker track:start endDate:endDate bytes:excellentStatePayload];
+    }
+
+    XCTAssertEqual([TestableTMNetworkSpeedTracker quality], TMNetworkSpeedQualityExcellent,
+                   "> 2000 kbps was not rated as 'Excellent'.");
 }
 
 @end


### PR DESCRIPTION
The network speed tracker was showing some strange speed readings. I've made the following changes to help with more accurate metrics:

- Get the start time from the beginning of the request, not the beginning of the response, to take into account the full round trip time
- Filter out responses that took less than 1ms, these small measurements can sometimes be from disk reads (despite filtering out requests that aren't network fetches, some cache hits do come through).
- Filter out responses <10kb
- Add an additional tier of speed measurement

How to test:
Run the unit tests and make sure they pass