### PR TITLE
fix incorrect nonnull annotation

### DIFF
--- a/Classes/Networking/RequestBody/TMGZIPEncodedRequestBody.m
+++ b/Classes/Networking/RequestBody/TMGZIPEncodedRequestBody.m
@@ -13,7 +13,7 @@
 @interface TMGZIPEncodedRequestBody ()
 
 @property (nonatomic, nonnull, readonly) id<TMRequestBody> originalBody;
-@property (nonatomic, nonnull, readonly) NSData *compressedBodyData;
+@property (nonatomic, nullable, readonly) NSData *compressedBodyData;
 
 @end
 


### PR DESCRIPTION
I missed this in my original PR, this annotation is incorrect as a failure gzipping the request body could result in `compressedBodyData` being `nil`