### PR TITLE
Add description to TMAPIRequest

### DIFF
--- a/Classes/Networking/RequestBody/TMFormEncodedRequestBody.m
+++ b/Classes/Networking/RequestBody/TMFormEncodedRequestBody.m
@@ -28,6 +28,10 @@
     return self;
 }
 
+- (nonnull NSString *)description {
+    return [NSString stringWithFormat:@"<%@: %p, %@, %@>", NSStringFromClass([self class]), self, self.contentType, self.parameters];
+}
+
 #pragma mark - TMRequestBody
 
 - (nullable NSData *)bodyData {

--- a/Classes/Networking/RequestBody/TMGZIPEncodedRequestBody.m
+++ b/Classes/Networking/RequestBody/TMGZIPEncodedRequestBody.m
@@ -5,7 +5,6 @@
 //  Created by Michael Benedict on 2/9/18.
 //
 
-#import "TMRequestBody.h"
 #import "TMGZIPEncodedRequestBody.h"
 #include <zlib.h>
 #define CHUNKSIZE (1024*4)
@@ -29,6 +28,10 @@
     }
     
     return self;
+}
+
+- (nonnull NSString *)description {
+    return [NSString stringWithFormat:@"<%@: %p, originalBody=%@>", NSStringFromClass([self class]), self, self.originalBody];
 }
 
 #pragma mark - TMRequestBody

--- a/Classes/Networking/RequestBody/TMJSONEncodedRequestBody.m
+++ b/Classes/Networking/RequestBody/TMJSONEncodedRequestBody.m
@@ -27,6 +27,10 @@
     return self;
 }
 
+- (nonnull NSString *)description {
+    return [NSString stringWithFormat:@"<%@: %p, %@, %@>", NSStringFromClass([self class]), self, self.contentType, self.JSONDictionary];
+}
+
 #pragma mark - TMRequestBody
 
 - (nullable NSString *)contentType {

--- a/Classes/Networking/RequestBody/TMMultipartRequestBody.m
+++ b/Classes/Networking/RequestBody/TMMultipartRequestBody.m
@@ -56,6 +56,12 @@
     return self;
 }
 
+- (nonnull NSString *)description {
+    return [NSString stringWithFormat:@"<%@: %p, %@, %@>", NSStringFromClass([self class]), self, self.contentType, self.parameters];
+}
+
+#pragma mark - TMRequestBody
+
 - (nullable NSString *)contentType {
     return [[NSString alloc] initWithFormat:@"multipart/form-data; charset=utf-8; boundary=%@", TMMultipartBoundary];
 }

--- a/Classes/TMRequest/TMAPIRequest.m
+++ b/Classes/TMRequest/TMAPIRequest.m
@@ -133,4 +133,8 @@
     return YES;
 }
 
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@: %p, %@, %@, %@>", NSStringFromClass([self class]), self, self.URL.absoluteString, self.queryParameters, self.requestBody];
+}
+
 @end


### PR DESCRIPTION
Adding relevant information to description to make NSLog/print debug easier.

**before**

    <TMAPIRequest: 0x1c4071c00>

**after**

    <TMAPIRequest: 0x1c0075a40, https://api-http2.tumblr.com/v2/blog/taichino-test.tumblr.com/post, (null), <TMMultipartRequestBody: 0x1c00775c0, multipart/form-data; charset=utf-8; boundary=TumblrBoundary, {
        "attach_reblog_tree" = 1;
        caption = "";
        context = Dashboard;
        creation_tools[0][attribution]" = "com.tumblr.gifmaker";
        "creation_tools[0][type]" = gif;
        format = html;
        "owner_flagged_nsfw" = false;
        "photoset_layout" = 1;
        "send_to_facebook" = no;
        state = published;
        tags = gif;
        tweet = off;
        type = photo;
    }>>