### PR TITLE
Fix (1021) OAUTH mismatch errors when the query parameters contain array

### DIFF
--- a/Classes/Networking/TMURLEncoding.m
+++ b/Classes/Networking/TMURLEncoding.m
@@ -81,7 +81,7 @@
     }
     else if ([object isKindOfClass:[NSArray class]]) {
         [(NSArray *)object enumerateObjectsUsingBlock:^(NSString *arrayObject, NSUInteger idx, BOOL * stop) {
-            NSString *arrayKey = [NSString stringWithFormat:@"%@[%lu]", objectKey,  (unsigned long)idx];
+            NSString *arrayKey = [NSString stringWithFormat:@"%@[%lu]", objectKey, (unsigned long)idx];
             [self encodeObject:arrayObject withKey:arrayKey andSubKey:nil intoArray:array];
         }];
     }

--- a/Classes/Networking/TMURLEncoding.m
+++ b/Classes/Networking/TMURLEncoding.m
@@ -81,7 +81,8 @@
     }
     else if ([object isKindOfClass:[NSArray class]]) {
         [(NSArray *)object enumerateObjectsUsingBlock:^(NSString *arrayObject, NSUInteger idx, BOOL * stop) {
-            [self encodeObject:arrayObject withKey:objectKey andSubKey:[[NSString alloc] initWithFormat:@"%lu", (unsigned long)idx] intoArray:array];
+            NSString *arrayKey = [[NSString alloc] initWithFormat:@"%@[%lu]", objectKey,  (unsigned long)idx];
+            [self encodeObject:arrayObject withKey:arrayKey andSubKey:nil intoArray:array];
         }];
     }
     else if ([object isKindOfClass:[NSNumber class]]) {

--- a/Classes/Networking/TMURLEncoding.m
+++ b/Classes/Networking/TMURLEncoding.m
@@ -80,10 +80,9 @@
         }
     }
     else if ([object isKindOfClass:[NSArray class]]) {
-        for (NSString *arrayObject in (NSArray *)object) {
-            NSString *arrayKey = [[NSString alloc] initWithFormat:@"%@[]", objectKey];
-            [self encodeObject:arrayObject withKey:arrayKey andSubKey:nil intoArray:array];
-        }
+        [(NSArray *)object enumerateObjectsUsingBlock:^(NSString *arrayObject, NSUInteger idx, BOOL * stop) {
+            [self encodeObject:arrayObject withKey:objectKey andSubKey:[[NSString alloc] initWithFormat:@"%lu", (unsigned long)idx] intoArray:array];
+        }];
     }
     else if ([object isKindOfClass:[NSNumber class]]) {
         [array addObject:[[NSString alloc] initWithFormat:@"%@=%@", objectKey, [object stringValue]]];

--- a/Classes/Networking/TMURLEncoding.m
+++ b/Classes/Networking/TMURLEncoding.m
@@ -81,7 +81,7 @@
     }
     else if ([object isKindOfClass:[NSArray class]]) {
         [(NSArray *)object enumerateObjectsUsingBlock:^(NSString *arrayObject, NSUInteger idx, BOOL * stop) {
-            NSString *arrayKey = [[NSString alloc] initWithFormat:@"%@[%lu]", objectKey,  (unsigned long)idx];
+            NSString *arrayKey = [NSString stringWithFormat:@"%@[%lu]", objectKey,  (unsigned long)idx];
             [self encodeObject:arrayObject withKey:arrayKey andSubKey:nil intoArray:array];
         }];
     }

--- a/Classes/TMSDKFunctions.m
+++ b/Classes/TMSDKFunctions.m
@@ -63,7 +63,9 @@ NSDictionary *TMQueryStringToDictionary(NSString *query) {
 NSString *TMDictionaryToQueryString(NSDictionary *dictionary) {
     NSMutableArray *parameters = [NSMutableArray array];
     
-    for (NSString *key in [[dictionary allKeys] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]) {
+    for (NSString *key in [[dictionary allKeys] sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
+        return [TMURLEncode(obj1) compare:TMURLEncode(obj2) options:NSCaseInsensitiveSearch] == NSOrderedDescending;
+    }]) {
         TMAddKeyValuePairToQueryStringMutableArray(key, dictionary[key], parameters);
     }
     

--- a/ExampleiOS/ExampleiOSTests/TMOAuthTests.m
+++ b/ExampleiOS/ExampleiOSTests/TMOAuthTests.m
@@ -28,6 +28,20 @@
     XCTAssert([signedURL.absoluteString isEqualToString:@"https://tumblr.com/?oauth_consumer_key=consumerKey&oauth_nonce=1234&oauth_signature=w/LP1MdJwiCfakR3GbW9IoeOz1E%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1511967770&oauth_token=token&oauth_version=1.0"], @"The generated OAuth signature should match the expected value.");
 }
 
+- (void)testSignUrlWithQueryWithArrayParams {
+    NSURL *signedURL = [TMOAuth signUrlWithQueryComponent:[NSURL URLWithString:@"https://tumblr.com/?rollups=true&types[0]=like&types[1]=follow&types[10]=post_appeal_accepted&types[11]=mention_in_reply&types[12]=ask&types[13]=reblog_naked&types[14]=post_appeal_rejected&types[15]=reply&types[2]=answered_ask&types[3]=new_group_blog_member&types[4]=post_attribution&types[5]=reblog_with_content&types[6]=post_flagged&types[7]=what_you_missed&types[8]=mention_in_post&types[9]=conversational_note"]
+                                                   method:@"GET"
+                                           postParameters:[NSDictionary dictionary]
+                                                    nonce:@"1234"
+                                              consumerKey:@"consumerKey"
+                                           consumerSecret:@"consumerSecret"
+                                                    token:@"token"
+                                              tokenSecret:@"tokenSecret"
+                                                timestamp:@"1511967770"];
+    XCTAssert([signedURL.absoluteString isEqualToString:@"https://tumblr.com/?rollups=true&types%5B0%5D=like&types%5B1%5D=follow&types%5B10%5D=post_appeal_accepted&types%5B11%5D=mention_in_reply&types%5B12%5D=ask&types%5B13%5D=reblog_naked&types%5B14%5D=post_appeal_rejected&types%5B15%5D=reply&types%5B2%5D=answered_ask&types%5B3%5D=new_group_blog_member&types%5B4%5D=post_attribution&types%5B5%5D=reblog_with_content&types%5B6%5D=post_flagged&types%5B7%5D=what_you_missed&types%5B8%5D=mention_in_post&types%5B9%5D=conversational_note?oauth_consumer_key=consumerKey&oauth_nonce=1234&oauth_signature=Kn9oxNY8jR5crhBPjn10pXmsm/k%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1511967770&oauth_token=token&oauth_version=1.0"],
+              @"The generated OAuth signature should match the expected value.");
+}
+
 - (void)testInitSetsInstanceVariables {
     TMOAuth *tmOAuth = [[TMOAuth alloc] initWithURL:[NSURL URLWithString:@"https://tumblr.com/"] method:@"GET" postParameters:[NSDictionary dictionary] nonce:@"1234" consumerKey:@"consumerKey" consumerSecret:@"consumerSecret" token:@"token" tokenSecret:@"tokenSecret"];
 

--- a/ExampleiOS/ExampleiOSTests/TMURLEncodingTests.m
+++ b/ExampleiOS/ExampleiOSTests/TMURLEncodingTests.m
@@ -44,7 +44,7 @@
 - (void)testFormDictionaryWithArray {
     NSString *string = [TMURLEncoding formEncodedDictionary:@{@"hello" : @[@3, @"da"]}];
 
-    XCTAssertEqualObjects(@"hello%5B%5D=3&hello%5B%5D=da", string);
+    XCTAssertEqualObjects(@"hello[0]=3&hello[1]=da", string);
 }
 
 - (void)testEncodingEmptyDictionary {

--- a/ExampleiOS/ExampleiOSTests/TMURLEncodingTests.m
+++ b/ExampleiOS/ExampleiOSTests/TMURLEncodingTests.m
@@ -44,7 +44,7 @@
 - (void)testFormDictionaryWithArray {
     NSString *string = [TMURLEncoding formEncodedDictionary:@{@"hello" : @[@3, @"da"]}];
 
-    XCTAssertEqualObjects(@"hello[0]=3&hello[1]=da", string);
+    XCTAssertEqualObjects(@"hello%5B0%5D=3&hello%5B1%5D=da", string);
 }
 
 - (void)testEncodingEmptyDictionary {

--- a/TMTumblrSDK.podspec.json
+++ b/TMTumblrSDK.podspec.json
@@ -1,11 +1,11 @@
 {
   "name": "TMTumblrSDK",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "summary": "An unopinionated and flexible library for easily integrating Tumblr data into your iOS or OS X application.",
   "homepage": "https://github.com/tumblr/TMTumblrSDK",
   "source": {
     "git": "https://github.com/tumblr/TMTumblrSDK.git",
-    "tag": "5.3.2"
+    "tag": "5.3.3"
   },
   "license": {
     "type": "Apache 2.0",


### PR DESCRIPTION
There are mainly 2 different cases this PR fixes.

**1. The case where you construct your array query parameters using indices like:**

```
https://wppinar.dca.tumblr.net/v2/blog/someblog/notifications?rollups=true&types[0]=post_attribution&types[1]=post_flagged&types[2]=new_group_blog_member&types[3]=post_appeal_accepted&types[4]=conversational_note&types[5]=what_you_missed&types[6]=post_appeal_rejected
```

**2. The case you construct them without indices:**

```
https://wppinar.dca.tumblr.net/v2/blog/someblog/notifications?rollups=true&types[]=post_attribution&types[]=post_flagged&types[]=new_group_blog_member&types[]=post_appeal_accepted&types[]=conversational_note&types[]=what_you_missed&types[]=post_appeal_rejected

```

**1st case**

We detected a case which caused the oath signature getting generated wrongly. It is when we have an array style query parameter that has more than 10 elements. The problem was the parameters on the iOS side was getting sorted before the base 64 encoding, but according to the [specs](https://tools.ietf.org/html/rfc5849#section-3.4.1.3.2) we need to sort the encoded versions of them. This problem only manifested itself with array indices bigger than 9.

Left is what iOS is passing to the OAUTH signature function, right one is what server is expecting:
(I decoded the values for better readability):

<img width="1610" alt="Screen Shot 2021-01-06 at 13 47 42" src="https://user-images.githubusercontent.com/5032900/104004027-4f388780-51b4-11eb-8bed-65e74a2e2af1.png">

iOS sorts the indexes like: 0, 10, 1, 2, 3 ....
Serverside: 0, 1, 10, 2, 3 ....

Since:

Un-encoded sort results in:

types=[0],
types=[10],
types=[1]
.
.
.

Sorting **after** encoding results in:

types=%5B0%5D,
types=%5B1%5D,
types=%5B10%5D
.
.
.

So my fix is updating this sort policy to use encoded values which seems like the right thing to do according to the [specs](https://tools.ietf.org/html/rfc5849#section-3.4.1.3.2). I am not changing the number of encodings done or the place encoding happens, but just changing the policy of the sort.

**2nd case**

We have a separate OAUTH mismatch error when try to scroll down in the page and request the next page from server. In this case the `next` request is parsed from the previous response, and as you see it has an array type parameter "types". iOS client generates such request when that happens:

https://wppinar.dca.tumblr.net/v2/blog/someblog/notifications?rollups=true&types[]=post_attribution&types[]=post_flagged&types[]=new_group_blog_member&types[]=post_appeal_accepted&types[]=conversational_note&types[]=what_you_missed&types[]=post_appeal_rejected

👆 And it is not accepted by server, it fails again with a 1021 OAUTH mismatch error. The server-side can not match it, it either wants no brackets or the brackets with indices in them(like types=post_flagged&types=new_group_blog_member or types[0]=post_flagged&types[1]=new_group_blog_member.(a detail: However, the no-brackets version is failing for some other reason so we have only one option left which is the indexed brackets))

```
		"_links": {
			"next": {
				"href": "/v2/blog/pinarolguc-pieceofme/notifications?rollups=true&types%5B0%5D=answered_ask&types%5B1%5D=post_attribution&types%5B2%5D=reblog_with_content&types%5B3%5D=conversational_note&types%5B4%5D=mention_in_post&types%5B5%5D=follow&types%5B6%5D=like&types%5B7%5D=ask&types%5B8%5D=reply&types%5B9%5D=reblog_naked&types%5B10%5D=what_you_missed&before=1605193536",
				"method": "GET",
				"query_params": {
					"rollups": "true",
					"types": ["answered_ask", "post_attribution", "reblog_with_content", "conversational_note", "mention_in_post", "follow", "like", "ask", "reply", "reblog_naked", "what_you_missed"],
					"before": "1605193536"
				}
			}
		}
```

So even though there's an if case in the code to handle arrays, constructing the query as below was not working at all. From now on we can just construct the query parameters as below and it will work.

````
        var queryParameters: [AnyHashable: Any] = [:]
        queryParameters["types"] = ["answered_ask", "post_attribution", ....]
        let apiRequest = TMAPIRequest(baseURL: ..., method: .GET, path: ..., queryParameters: queryParameters)

````


As far as I see it is the first time we are trying to make a "next" request with "query_params" that has an array in it. What is more, I couldn't find any other endpoint call in Tumblr iOS client that has any array in url parameters.

**To Test**

On this particular PR the unit test should be green.

(I'll open a separate PR on the main app to test this change end-to-end.)