### PR TITLE
Fix warning "implicit conversion loses integer precision: 'long long' to 'NSUInteger'"

### DIFF
--- a/Classes/Networking/Multipart/TMEncodableMultipartFormData.m
+++ b/Classes/Networking/Multipart/TMEncodableMultipartFormData.m
@@ -79,7 +79,7 @@ NSUInteger const TMMaxBufferSize = 1024;
         *error = [[NSError alloc] initWithDomain:TMMultipartFormErrorDomain code:TMMultipartFormErrorTypeFileSizeNotAvailable userInfo:nil];
         return;
     }
-    NSUInteger contentLength = fileSizeNumber.longLongValue;
+    NSUInteger contentLength = fileSizeNumber.unsignedIntegerValue;
     
     // Can we create the input stream?
     NSInputStream *inputStream = [[NSInputStream alloc] initWithURL:fileURL];


### PR DESCRIPTION
Fixes below warning:

"implicit conversion loses integer precision: 'long long' to 'NSUInteger'"