### PR TITLE
Fix the construction of the background upload request when its body is NOT a multipart form

### DIFF
--- a/Classes/TMURLSession.m
+++ b/Classes/TMURLSession.m
@@ -225,7 +225,12 @@ NSString * _Nonnull const TMURLSessionInvalidateHTTPHeadersNotificationKey = @"T
             NSAssert(NO, @"Failed to encode multipart body request.");
             return nil;
         }
-    } else {
+    }
+    else {
+        NSData *bodyData = [request.requestBody bodyData];
+        form = [[TMMultipartEncodedForm alloc] initWithData:bodyData];
+    }
+    if (!form.fileURL) {
         NSAssert(NO, @"Background tasks must be encoded into a file.");
         return nil;
     }

--- a/ExampleiOS/ExampleiOSTests/ExampleiOSTests-Bridging-Header.h
+++ b/ExampleiOS/ExampleiOSTests/ExampleiOSTests-Bridging-Header.h
@@ -2,3 +2,4 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
+#import "TMBaseTestCase.h"

--- a/ExampleiOS/ExampleiOSTests/TMURLSessionTests.swift
+++ b/ExampleiOS/ExampleiOSTests/TMURLSessionTests.swift
@@ -10,7 +10,7 @@ import Foundation
 import TMTumblrSDK
 import XCTest
 
-final class TMURLSessionTests: XCTestCase {
+final class TMURLSessionTests: TMBaseTestCase {
     
     let URLSessionManager = TMURLSession(configuration: URLSessionConfiguration.default, applicationCredentials: TMAPIApplicationCredentials(consumerKey: "kenny", consumerSecret: "paul"), userCredentials: TMAPIUserCredentials(token: "token'", tokenSecret: "ht"))
 
@@ -214,6 +214,27 @@ final class TMURLSessionTests: XCTestCase {
         }
 
         XCTAssertEqual(headers, ["tape": "tumblr"])
+    }
+    
+    func testUploadBackgroundTaskWithSinglePartRequest() throws {
+        let sessionManager = TMURLSession(configuration: URLSessionConfiguration.default,
+                                          applicationCredentials: TMAPIApplicationCredentials(consumerKey: "kenny", consumerSecret: "paul"),
+                                          userCredentials: TMAPIUserCredentials(token: "token", tokenSecret: "ht"),
+                                          networkActivityManager: nil,
+                                          sessionTaskUpdateDelegate: nil,
+                                          sessionMetricsDelegate: nil,
+                                          requestTransformer: nil,
+                                          customURLSessionDataDelegate: nil,
+                                          additionalHeaders: nil)
+        
+        let request = TMAPIRequest(baseURL: try XCTUnwrap(URL(string: "http://test.com")),
+                     method: .POST,
+                     path: "path",
+                     queryParameters: nil,
+                     requestBody: TMQueryEncodedRequestBody(queryDictionary: [String: AnyObject]()),
+                     additionalHeaders: nil)
+        let task = sessionManager.backgroundUploadTask(with: request)
+        XCTAssertNotNil(task)
     }
 
     // MARK: -

--- a/TMTumblrSDK.podspec.json
+++ b/TMTumblrSDK.podspec.json
@@ -1,11 +1,11 @@
 {
   "name": "TMTumblrSDK",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "summary": "An unopinionated and flexible library for easily integrating Tumblr data into your iOS or OS X application.",
   "homepage": "https://github.com/tumblr/TMTumblrSDK",
   "source": {
     "git": "https://github.com/tumblr/TMTumblrSDK.git",
-    "tag": "6.0.0"
+    "tag": "6.0.1"
   },
   "license": {
     "type": "Apache 2.0",


### PR DESCRIPTION
## What does it do?

There's a case that was overlooked in the [previous PR](https://github.com/tumblr/TMTumblrSDK/pull/169) that adds support for background uploads. Not all upload requests must have multipart request bodies, especially when there's no media attached to the form. So we are fixing it in this PR, letting to create a background upload request even when the request body is not a multipart form.

## To Test

Run unit tests in your local.
(I'll open a separate PR on the main app to test this change end-to-end.)
