### PR TITLE
Query parameters for permalink request

### DIFF
--- a/Classes/TMRequestFactory.h
+++ b/Classes/TMRequestFactory.h
@@ -254,7 +254,7 @@ __attribute__((objc_subclassing_restricted))
  *
  *  @return A new request to fetch a permalink content package.
  */
-- (nonnull id <TMRequest>)permalinkRequestWithBlogName:(nonnull NSString *)blogName postID:(nonnull NSString *)postID;
+- (nonnull id <TMRequest>)permalinkRequestWithBlogName:(nonnull NSString *)blogName postID:(nonnull NSString *)postID queryParameters:(nullable NSDictionary *)queryParameters;
 
 /*
  *  Creates a request that fetches an individual blog post and its associated recommended content.
@@ -264,7 +264,7 @@ __attribute__((objc_subclassing_restricted))
  *
  *  @return A new request to fetch a permalink content package.
  */
-- (nonnull id <TMRequest>)permalinkRequestWithBlogUUID:(nonnull NSString *)blogUUID postID:(nonnull NSString *)postID;
+- (nonnull id <TMRequest>)permalinkRequestWithBlogUUID:(nonnull NSString *)blogUUID postID:(nonnull NSString *)postID queryParameters:(nullable NSDictionary *)queryParameters;
 
 /**
  *  Makes a request that creates a new blog post.

--- a/Classes/TMRequestFactory.m
+++ b/Classes/TMRequestFactory.m
@@ -276,18 +276,18 @@ NSString * _Nonnull const TMRequestFactoryInvalidateBaseURLNotificationKey = @"T
     return [self requestWithPath:blogPath(TMRouteBlogPathPosts, blogName) method:TMHTTPRequestMethodGET queryParameters:[mutableParameters copy]];
 }
 
-- (nonnull id <TMRequest>)permalinkRequestWithBlogName:(nonnull NSString *)blogName postID:(nonnull NSString *)postID {
+- (nonnull id <TMRequest>)permalinkRequestWithBlogName:(nonnull NSString *)blogName postID:(nonnull NSString *)postID queryParameters:(nullable NSDictionary *)queryParameters {
     NSParameterAssert(blogName);
     NSParameterAssert(postID);
 
-    return [self requestWithPath:[NSString stringWithFormat:@"blog/%@/posts/%@/permalink", fullBlogName(blogName), postID] method:TMHTTPRequestMethodGET queryParameters:nil];
+    return [self requestWithPath:[NSString stringWithFormat:@"blog/%@/posts/%@/permalink", fullBlogName(blogName), postID] method:TMHTTPRequestMethodGET queryParameters:queryParameters];
 }
 
-- (nonnull id <TMRequest>)permalinkRequestWithBlogUUID:(nonnull NSString *)blogUUID postID:(nonnull NSString *)postID {
+- (nonnull id <TMRequest>)permalinkRequestWithBlogUUID:(nonnull NSString *)blogUUID postID:(nonnull NSString *)postID queryParameters:(nullable NSDictionary *)queryParameters {
     NSParameterAssert(blogUUID);
     NSParameterAssert(postID);
 
-    return [self requestWithPath:[NSString stringWithFormat:@"blog/%@/posts/%@/permalink", TMURLEncode(blogUUID), postID] method:TMHTTPRequestMethodGET queryParameters:nil];
+    return [self requestWithPath:[NSString stringWithFormat:@"blog/%@/posts/%@/permalink", TMURLEncode(blogUUID), postID] method:TMHTTPRequestMethodGET queryParameters:queryParameters];
 }
 
 - (nonnull id <TMRequest>)postRequestWithBlogName:(nonnull NSString *)blogName type:(nullable NSString *)type parameters:(nonnull NSDictionary *)parameters {


### PR DESCRIPTION
Currently the query parameters sent in `"blog/blog_name/posts/post_id/permalink"` is `nil`.
Looking into this [ADSPRODUCT-2466](https://jira.tumblr.net/browse/ADSPRODUCT-2466) and this [ADSPRODUCT-2443](https://jira.tumblr.net/browse/ADSPRODUCT-2466) I found that we need more info from the blog object.
Specifically a field called `"is_blogless_advertiser"`.

This PR only modifies the permalink request to accept optional query parameters.