### PR TITLE
add parameters to unfollow request

### DIFF
--- a/Classes/TMRequestFactory.h
+++ b/Classes/TMRequestFactory.h
@@ -148,6 +148,15 @@ __attribute__((objc_subclassing_restricted))
  *  Creates a new request that unfollows a blog.
  *
  *  @param blogName The blog we want to unfollow.
+ *
+ *  @return A new request that allows you to unfollow a blog.
+ */
+- (nonnull id <TMRequest>)unfollowRequest:(nonnull NSString *)blogName;
+
+/**
+ *  Creates a new request that unfollows a blog.
+ *
+ *  @param blogName The blog we want to unfollow.
  *  @param parameters Additional parameters on the request.
  *
  *  @return A new request that allows you to unfollow a blog.

--- a/Classes/TMRequestFactory.h
+++ b/Classes/TMRequestFactory.h
@@ -148,10 +148,11 @@ __attribute__((objc_subclassing_restricted))
  *  Creates a new request that unfollows a blog.
  *
  *  @param blogName The blog we want to unfollow.
+ *  @param parameters Additional parameters on the request.
  *
  *  @return A new request that allows you to unfollow a blog.
  */
-- (nonnull id <TMRequest>)unfollowRequest:(nonnull NSString *)blogName;
+- (nonnull id <TMRequest>)unfollowRequest:(nonnull NSString *)blogName parameters:(nullable NSDictionary *)parameters;
 
 /**
  *  Creates a URL request for making a GET request to the API's 'v2/user/info' route

--- a/Classes/TMRequestFactory.m
+++ b/Classes/TMRequestFactory.m
@@ -130,6 +130,12 @@ NSString * _Nonnull const TMRequestFactoryInvalidateBaseURLNotificationKey = @"T
 
 }
 
+- (nonnull id <TMRequest>)unfollowRequest:(nonnull NSString *)blogName {
+    
+    return [self unfollowRequest:blogName
+                      parameters:nil];
+}
+
 - (nonnull id <TMRequest>)unfollowRequest:(nonnull NSString *)blogName parameters:(nullable NSDictionary *)parameters {
     NSParameterAssert(blogName);
     NSMutableDictionary *requestParameters = [NSMutableDictionary dictionary];

--- a/Classes/TMRequestFactory.m
+++ b/Classes/TMRequestFactory.m
@@ -130,13 +130,18 @@ NSString * _Nonnull const TMRequestFactoryInvalidateBaseURLNotificationKey = @"T
 
 }
 
-- (nonnull id <TMRequest>)unfollowRequest:(nonnull NSString *)blogName {
+- (nonnull id <TMRequest>)unfollowRequest:(nonnull NSString *)blogName parameters:(nullable NSDictionary *)parameters {
     NSParameterAssert(blogName);
+    NSMutableDictionary *requestParameters = [NSMutableDictionary dictionary];
+
+    [requestParameters setObject:fullBlogName(blogName) forKey:@"url"];
+    [requestParameters addEntriesFromDictionary:parameters];
+
     NSString * const TMRoutePathUnfollow = @"user/unfollow";
     return [self requestWithPath:TMRoutePathUnfollow
                           method:TMHTTPRequestMethodPOST
                  queryParameters:nil
-                     requestBody:[[TMFormEncodedRequestBody alloc] initWithBody:@{ @"url" : fullBlogName(blogName) }]];
+                     requestBody:[[TMFormEncodedRequestBody alloc] initWithBody:requestParameters]];
 }
 
 - (nonnull id <TMRequest>)followRequest:(nonnull NSString *)blogName parameters:(nullable NSDictionary *)parameters {


### PR DESCRIPTION
This pull request adds a new argument to the `unfollowRequest` method in the RequestFactory, allowing for the sending of additional body parameters. The new argument `parameters` is a dictionary of additional key-value pairs to be included in the request body.

This change is fully backwards compatible, as the new parameter is optional and has a default value of an nil dictionary. Existing code using the unfollow method will continue to work without any changes.

