### PR TITLE
Add baseURLStringPlusPath to the reason when throwing an error in TMAPIRequest::URL

### DIFF
--- a/Classes/TMRequest/TMAPIRequest.m
+++ b/Classes/TMRequest/TMAPIRequest.m
@@ -123,7 +123,9 @@
     NSURL *URL = [NSURL URLWithString:baseURLStringPlusPath];
 
     if (!URL) {
-        @throw [[NSException alloc] initWithName:@"Illegal URL or Path exception" reason:@"The URL generated was nil." userInfo:nil];
+        @throw [[NSException alloc] initWithName:@"Illegal URL or Path exception"
+                                          reason:[NSString stringWithFormat: @"The URL generated was nil. baseURLStringPlusPath: %@", baseURLStringPlusPath]
+                                        userInfo:nil];
     }
 
     return URL;


### PR DESCRIPTION
Let's add `baseURLStringPlusPath` to the reason to make crash logs more useful.