### PR TITLE
The root level object can be a list of strings

### DIFF
--- a/Classes/include/TMParsedHTTPResponse.h
+++ b/Classes/include/TMParsedHTTPResponse.h
@@ -35,7 +35,7 @@ __attribute__((objc_subclassing_restricted))
                                      APIErrors:(nonnull NSArray <id <TMAPIError>> *)APIErrors
                                     statusCode:(NSInteger)statusCode;
 
-- (nonnull instancetype)initWithJSONArray:(nullable NSArray<NSDictionary<NSString *, id> *> *)JSONArray
+- (nonnull instancetype)initWithJSONArray:(nullable NSArray<id> *)JSONArray
                                successful:(BOOL)successful
                       responseDescription:(nullable NSString *)responseDescription
                                     error:(nullable NSError *)error
@@ -47,7 +47,7 @@ __attribute__((objc_subclassing_restricted))
  */
 @property (nonatomic, nullable, copy, readonly) NSDictionary<NSString *, id> *JSONDictionary;
 
-@property (nonatomic, nullable, copy, readonly) NSArray<NSDictionary<NSString *, id> *> *JSONArray;
+@property (nonatomic, nullable, copy, readonly) NSArray<id> *JSONArray;
 
 /**
  *  Whether or not the HTTP requst was successful or not.


### PR DESCRIPTION
I noticed that some endpoint returns a list of strings in addition to list of objects. 

The following is a response from `/v2/user/reset` endpoint.

```
{
  "meta": {
    "status": 200,
    "msg": "OK"
  },
  "response": [
    "Your password reset has been sent!"
  ]
}
```